### PR TITLE
Add FastAPI user service skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+.env
+venv/
+.env.*
+__test__/
+.idea/
+.vscode/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY pyproject.toml .
-RUN pip install poetry
-RUN poetry config virtualenvs.create false && poetry install --no-dev
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["gunicorn", "app.main:app", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:80"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# User Service
+
+This is a simple FastAPI based microservice providing user management and profile features. It demonstrates database per service, clean architecture ideas and supports JWT authentication with access and refresh tokens.
+
+## Development
+
+### Requirements
+- Python 3.11+
+- PostgreSQL
+
+### Running locally
+
+```bash
+pip install -r requirements.txt  # install dependencies
+uvicorn app.main:app --reload
+```
+
+### Tests
+
+Run unit tests with pytest:
+
+```bash
+pytest -q
+```
+
+### Container
+
+You can build and run the service with docker-compose:
+
+```bash
+docker-compose up --build
+```
+

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = alembic
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s:%(name)s:%(message)s
+

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,38 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+from sqlalchemy import create_engine
+from alembic import context
+import asyncio
+
+from app.core.config import settings
+from app import models
+
+config = context.config
+
+fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_online():
+    connectable = create_engine(settings.DATABASE_URL, poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, render_as_batch=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+def run_migrations():
+    run_migrations_online()
+
+
+if context.is_offline_mode():
+    raise RuntimeError("Offline mode not supported")
+else:
+    run_migrations()
+

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -5,7 +5,8 @@ from jose import jwt, JWTError
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import crud, models, schemas
+from app import crud, models
+from app.api.v1 import schemas
 from app.core.config import settings
 from app.db.session import AsyncSessionLocal
 

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import auth, users
+from app.api.v1.endpoints import auth, users, profiles
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
+api_router.include_router(profiles.router, prefix="/profiles", tags=["profiles"])

--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -1,0 +1,5 @@
+from .auth import router as auth_router
+from .users import router as users_router
+from .profiles import router as profiles_router
+
+__all__ = ["auth_router", "users_router", "profiles_router"]

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -3,7 +3,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import crud, schemas
+from app import crud
+from app.api.v1 import schemas
 from app.api import deps
 from app.core import security
 from app.core.config import settings

--- a/app/api/v1/endpoints/profiles.py
+++ b/app/api/v1/endpoints/profiles.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import crud, models
+from app.api.v1 import schemas
+from app.api import deps
+
+router = APIRouter()
+
+
+@router.get("/me", response_model=schemas.Profile)
+async def read_profile_me(current_user: models.User = Depends(deps.get_current_user), db: AsyncSession = Depends(deps.get_db)):
+    profile = await crud.profile.get_by_user_id(db, user_id=current_user.id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+
+@router.put("/me", response_model=schemas.Profile)
+async def update_profile_me(
+    *,
+    current_user: models.User = Depends(deps.get_current_user),
+    profile_in: schemas.ProfileUpdate,
+    db: AsyncSession = Depends(deps.get_db),
+):
+    profile = await crud.profile.get_by_user_id(db, user_id=current_user.id)
+    if not profile:
+        profile = await crud.profile.create(db, user_id=current_user.id, obj_in=schemas.ProfileCreate(**profile_in.model_dump()))
+        return profile
+    profile = await crud.profile.update(db, db_obj=profile, obj_in=profile_in)
+    return profile

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import crud, models, schemas
+from app import crud, models
+from app.api.v1 import schemas
 from app.api import deps
 
 router = APIRouter()

--- a/app/api/v1/schemas/__init__.py
+++ b/app/api/v1/schemas/__init__.py
@@ -1,0 +1,14 @@
+from .user import User, UserCreate, UserUpdate
+from .profile import Profile, ProfileCreate, ProfileUpdate
+from .token import Token, TokenPayload
+
+__all__ = [
+    "User",
+    "UserCreate",
+    "UserUpdate",
+    "Profile",
+    "ProfileCreate",
+    "ProfileUpdate",
+    "Token",
+    "TokenPayload",
+]

--- a/app/api/v1/schemas/profile.py
+++ b/app/api/v1/schemas/profile.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class ProfileBase(BaseModel):
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+
+
+class ProfileCreate(ProfileBase):
+    pass
+
+
+class ProfileUpdate(ProfileBase):
+    pass
+
+
+class Profile(ProfileBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/app/api/v1/schemas/user.py
+++ b/app/api/v1/schemas/user.py
@@ -1,16 +1,20 @@
 from pydantic import BaseModel, EmailStr
 from typing import Optional
 
+
 class UserBase(BaseModel):
     email: EmailStr
     full_name: Optional[str] = None
     is_active: Optional[bool] = True
 
+
 class UserCreate(UserBase):
     password: str
 
+
 class UserUpdate(UserBase):
     password: Optional[str] = None
+
 
 class UserInDBBase(UserBase):
     id: int
@@ -18,6 +22,7 @@ class UserInDBBase(UserBase):
 
     class Config:
         orm_mode = True
+
 
 class User(UserInDBBase):
     pass

--- a/app/core/observability.py
+++ b/app/core/observability.py
@@ -1,0 +1,6 @@
+from prometheus_fastapi_instrumentator import Instrumentator
+from fastapi import FastAPI
+
+
+def setup_observability(app: FastAPI) -> None:
+    Instrumentator().instrument(app).expose(app)

--- a/app/core/secrets.py
+++ b/app/core/secrets.py
@@ -1,0 +1,6 @@
+import os
+
+
+def get_secret(key: str) -> str:
+    """Retrieve secrets. Placeholder for integration with secret managers."""
+    return os.getenv(key, "")

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+from typing import Optional
+from jose import jwt
+from passlib.context import CryptContext
+
+from app.core.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def _create_token(*, user_id: int, expires_delta: timedelta) -> str:
+    to_encode = {
+        "exp": datetime.utcnow() + expires_delta,
+        "sub": str(user_id),
+    }
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def create_access_token(user_id: int, expires_delta: Optional[timedelta] = None) -> str:
+    if expires_delta is None:
+        expires_delta = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return _create_token(user_id=user_id, expires_delta=expires_delta)
+
+
+def create_refresh_token(user_id: int, expires_delta: Optional[timedelta] = None) -> str:
+    if expires_delta is None:
+        expires_delta = timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    return _create_token(user_id=user_id, expires_delta=expires_delta)

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,0 +1,4 @@
+from .user import CRUDUser, user
+from .profile import CRUDProfile, profile
+
+__all__ = ["CRUDUser", "user", "CRUDProfile", "profile"]

--- a/app/crud/profile.py
+++ b/app/crud/profile.py
@@ -1,0 +1,30 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from typing import Optional
+
+from app.models.profile import Profile
+from app.api.v1.schemas.profile import ProfileCreate, ProfileUpdate
+
+
+class CRUDProfile:
+    async def get_by_user_id(self, db: AsyncSession, *, user_id: int) -> Optional[Profile]:
+        result = await db.execute(select(Profile).filter(Profile.user_id == user_id))
+        return result.scalars().first()
+
+    async def create(self, db: AsyncSession, *, user_id: int, obj_in: ProfileCreate) -> Profile:
+        db_obj = Profile(user_id=user_id, **obj_in.model_dump())
+        db.add(db_obj)
+        await db.commit()
+        await db.refresh(db_obj)
+        return db_obj
+
+    async def update(self, db: AsyncSession, *, db_obj: Profile, obj_in: ProfileUpdate) -> Profile:
+        update_data = obj_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        await db.commit()
+        await db.refresh(db_obj)
+        return db_obj
+
+
+profile = CRUDProfile()

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,9 +1,11 @@
 from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
+
 from app.models.user import User
-from app.schemas.user import UserCreate, UserUpdate
+from app.api.v1.schemas.user import UserCreate, UserUpdate
 from app.core.security import get_password_hash, verify_password
+
 
 class CRUDUser:
     async def get(self, db: AsyncSession, *, id: int) -> Optional[User]:
@@ -27,27 +29,22 @@ class CRUDUser:
         return db_obj
 
     async def update(self, db: AsyncSession, *, db_obj: User, obj_in: UserUpdate) -> User:
-        if isinstance(obj_in, dict):
-            update_data = obj_in
-        else:
-            update_data = obj_in.dict(exclude_unset=True)
+        update_data = obj_in.model_dump(exclude_unset=True)
+        if "password" in update_data:
+            db_obj.hashed_password = get_password_hash(update_data.pop("password"))
+        for field, value in update_data.items():
+            setattr(db_obj, field, value)
+        await db.commit()
+        await db.refresh(db_obj)
+        return db_obj
 
-        if "password" in update_data and update_data["password"]:
-            hashed_password = get_password_hash(update_data["password"])
-            del update_data["password"]
-            db_obj.hashed_password = hashed_password
-        
-        return await super().update(db, db_obj=db_obj, obj_in=update_data)
-
-
-    async def authenticate(
-        self, db: AsyncSession, *, email: str, password: str
-    ) -> Optional[User]:
+    async def authenticate(self, db: AsyncSession, *, email: str, password: str) -> Optional[User]:
         user = await self.get_by_email(db, email=email)
         if not user:
             return None
         if not verify_password(password, user.hashed_password):
             return None
         return user
+
 
 user = CRUDUser()

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,22 @@
+import logging
 from fastapi import FastAPI
+
 from app.core.config import settings
+from app.core.observability import setup_observability
 from app.api.v1.api import api_router
+
+logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
-    openapi_url=f"{settings.API_V1_STR}/openapi.json"
+    openapi_url=f"{settings.API_V1_STR}/openapi.json",
 )
+
+setup_observability(app)
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
 
+
 @app.get("/")
-def read_root():
+async def read_root():
     return {"message": f"Welcome to {settings.PROJECT_NAME}"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,5 @@
+from app.db.base import Base  # noqa
+from app.models.user import User  # noqa
+from app.models.profile import Profile  # noqa
+
+__all__ = ["User", "Profile", "Base"]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .user import User
+from .profile import Profile
+
+__all__ = ["User", "Profile"]

--- a/app/models/profile.py
+++ b/app/models/profile.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, unique=True)
+    first_name = Column(String(100), nullable=True)
+    last_name = Column(String(100), nullable=True)
+
+    user = relationship("User", back_populates="profile")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,5 +1,8 @@
 from sqlalchemy import Column, Integer, String, Boolean
+from sqlalchemy.orm import relationship
+
 from app.db.base import Base
+
 
 class User(Base):
     __tablename__ = "users"
@@ -10,3 +13,5 @@ class User(Base):
     hashed_password = Column(String(255), nullable=False)
     is_active = Column(Boolean(), default=True)
     is_superuser = Column(Boolean(), default=False)
+
+    profile = relationship("Profile", back_populates="user", uselist=False)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: example
+      POSTGRES_DB: user_service_db
+    ports:
+      - "5432:5432"
+  web:
+    build: .
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: example
+      POSTGRES_SERVER: db
+      POSTGRES_DB: user_service_db
+    depends_on:
+      - db
+    ports:
+      - "8000:80"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic[email]==2.7.3
+pydantic-settings==2.2.1
+sqlalchemy[asyncio]==2.0.30
+asyncpg==0.29.0
+alembic==1.13.1
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+python-multipart==0.0.9
+gunicorn==21.2.0
+prometheus-fastapi-instrumentator==6.1.0
+opentelemetry-sdk==1.22.0
+opentelemetry-instrumentation-fastapi==0.43b0
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,42 @@
+pytest_plugins = ["pytest_asyncio"]
+import os
+import sys
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
-# ... setup test database and client
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-def override_get_db():
-    # ... return a test database session
-    pass
+from app.main import app
+from app.db.base import Base
+from app.api import deps
 
-app.dependency_overrides[deps.get_db] = override_get_db
+
+@pytest.fixture(scope="session")
+def db_engine():
+    test_engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async def init_models():
+        async with test_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    import asyncio
+    asyncio.get_event_loop().run_until_complete(init_models())
+    yield test_engine
+    asyncio.get_event_loop().run_until_complete(test_engine.dispose())
+
+
+@pytest.fixture(scope="function")
+def db_session(db_engine):
+    async_session = sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async def get_session():
+        async with async_session() as session:
+            yield session
+    return get_session
+
+
+@pytest.fixture(scope="function")
+def client(db_session):
+    app.dependency_overrides[deps.get_db] = db_session
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()

--- a/tests/test_user_flow.py
+++ b/tests/test_user_flow.py
@@ -1,0 +1,15 @@
+import pytest
+from app.api.v1 import schemas
+
+
+def test_user_registration_and_login(client):
+    user_data = {"email": "test@example.com", "password": "secret", "full_name": "Test User"}
+    resp = client.post("/api/v1/users/", json=user_data)
+    assert resp.status_code == 201
+    user = schemas.User(**resp.json())
+    assert user.email == user_data["email"]
+
+    resp = client.post("/api/v1/auth/login", data={"username": user_data["email"], "password": user_data["password"]})
+    assert resp.status_code == 200
+    token = schemas.Token(**resp.json())
+    assert token.access_token


### PR DESCRIPTION
## Summary
- implement user CRUD with SQLAlchemy async models
- add profile model and endpoints
- secure auth via JWT tokens
- dockerize with gunicorn and compose
- basic test for user signup/login

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6867db8d9fdc832cb45f5b38980d5130